### PR TITLE
Iss34/autotests rental session

### DIFF
--- a/rental_backend/routes/exc_handlers.py
+++ b/rental_backend/routes/exc_handlers.py
@@ -54,10 +54,3 @@ async def inactive_session_error_handler(req: starlette.requests.Request, exc: I
     return JSONResponse(
         content=StatusResponseModel(status="Error", message=exc.eng, ru=exc.ru).model_dump(), status_code=409
     )
-
-
-@app.exception_handler(ForbiddenAction)
-async def forbidden_action_error_handler(req: starlette.requests.Request, exc: ForbiddenAction):
-    return JSONResponse(
-        content=StatusResponseModel(status="Error", message=exc.eng, ru=exc.ru).model_dump(), status_code=403
-    )

--- a/rental_backend/routes/rental_session.py
+++ b/rental_backend/routes/rental_session.py
@@ -7,7 +7,7 @@ from fastapi_sqlalchemy import db
 
 from rental_backend.exceptions import ForbiddenAction, InactiveSession, NoneAvailable, ObjectNotFound
 from rental_backend.models.db import Item, ItemType, RentalSession, Strike
-from rental_backend.schemas.models import RentalSessionGet, RentalSessionPatch, RentStatus, StrikeGet, StrikePost
+from rental_backend.schemas.models import RentalSessionGet, RentalSessionPatch, RentStatus, StrikePost
 from rental_backend.utils.action import ActionLogger
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,3 +167,15 @@ def model_to_dict(model: BaseDbModel) -> Dict[str, Any]:
     for col in model.__table__.columns:
         model_dict[col.name] = getattr(model, col.name)
     return model_dict
+
+
+def make_url_query(data: Dict) -> str:
+    """Вспомогательная функция для преобразования входных данных
+    в строку параметров URL.
+    """
+    if len(data) == 0:
+        return ''
+    if len(data) == 1:
+        for k in data:
+            return f'?{k}={data[k]}'
+    return '?' + '&'.join(f'{k}={data[k]}' for k in data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def client(mocker, authlib_user):
     user_mock.return_value = authlib_user
     # app.build_middleware_stack  # TODO: Посмотреть в сторону этих замещений. Тогда тесты и сервис будут разведены. https://github.com/fastapi/fastapi/issues/2495
     # app.user_middleware
-    client = TestClient(app)  # , raise_server_exceptions=False)
+    client = TestClient(app, raise_server_exceptions=False)
     return client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ def authlib_user():
         "email": "string",
     }
 
+
 @pytest.fixture
 def another_authlib_user():
     """Данные об еще одном пользователе, возвращаемые сервисом auth.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,11 +26,54 @@ def authlib_user():
         "email": "string",
     }
 
+@pytest.fixture
+def another_authlib_user():
+    """Данные об еще одном пользователе, возвращаемые сервисом auth.
+
+    Составлено на основе: https://clck.ru/3LWzxt
+    """
+    return {
+        "auth_methods": ["string"],
+        "session_scopes": [{"id": 0, "name": "string"}],
+        "user_scopes": [{"id": 0, "name": "string"}],
+        "indirect_groups": [0],
+        "groups": [0],
+        "id": 1,
+        "email": "string",
+    }
+
 
 @pytest.fixture
-def client(mocker, authlib_user):
-    user_mock = mocker.patch('auth_lib.fastapi.UnionAuth.__call__')
-    user_mock.return_value = authlib_user
+def authlib_mock(mocker):
+    """Мок верификации AuthLib."""
+    auth_mock = mocker.patch('auth_lib.fastapi.UnionAuth.__call__')
+    return auth_mock
+
+
+@pytest.fixture
+def user_mock(authlib_mock, authlib_user):
+    """Мок UnionAuth с возвращением данных для authlib_user."""
+    authlib_mock.return_value = authlib_user
+    return authlib_mock
+
+
+@pytest.fixture
+def another_user_mock(authlib_mock, another_authlib_user):
+    """Мок UnionAuth с возвращением данных для another_authlib_user."""
+    authlib_mock.return_value = another_authlib_user
+    return authlib_mock
+
+
+@pytest.fixture
+def client(user_mock):
+    # app.build_middleware_stack  # TODO: Посмотреть в сторону этих замещений. Тогда тесты и сервис будут разведены. https://github.com/fastapi/fastapi/issues/2495
+    # app.user_middleware
+    client = TestClient(app, raise_server_exceptions=False)
+    return client
+
+
+@pytest.fixture
+def another_client(another_user_mock):
     # app.build_middleware_stack  # TODO: Посмотреть в сторону этих замещений. Тогда тесты и сервис будут разведены. https://github.com/fastapi/fastapi/issues/2495
     # app.user_middleware
     client = TestClient(app, raise_server_exceptions=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,7 @@ def dbsession():
     session = TestingSessionLocal()
     yield session
     session.query(Event).delete()
+    session.query(Strike).delete()
     session.query(RentalSession).delete()
     session.query(Item).delete()
     session.query(ItemType).delete()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,9 @@ def authlib_user():
 def client(mocker, authlib_user):
     user_mock = mocker.patch('auth_lib.fastapi.UnionAuth.__call__')
     user_mock.return_value = authlib_user
-    client = TestClient(app)
+    # app.build_middleware_stack  # TODO: Посмотреть в сторону этих замещений. Тогда тесты и сервис будут разведены. https://github.com/fastapi/fastapi/issues/2495
+    # app.user_middleware
+    client = TestClient(app, raise_server_exceptions=False)
     return client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,16 +66,12 @@ def another_user_mock(authlib_mock, another_authlib_user):
 
 @pytest.fixture
 def client(user_mock):
-    # app.build_middleware_stack  # TODO: Посмотреть в сторону этих замещений. Тогда тесты и сервис будут разведены. https://github.com/fastapi/fastapi/issues/2495
-    # app.user_middleware
     client = TestClient(app, raise_server_exceptions=False)
     return client
 
 
 @pytest.fixture
 def another_client(another_user_mock):
-    # app.build_middleware_stack  # TODO: Посмотреть в сторону этих замещений. Тогда тесты и сервис будут разведены. https://github.com/fastapi/fastapi/issues/2495
-    # app.user_middleware
     client = TestClient(app, raise_server_exceptions=False)
     return client
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def client(mocker, authlib_user):
     user_mock.return_value = authlib_user
     # app.build_middleware_stack  # TODO: Посмотреть в сторону этих замещений. Тогда тесты и сервис будут разведены. https://github.com/fastapi/fastapi/issues/2495
     # app.user_middleware
-    client = TestClient(app, raise_server_exceptions=False)
+    client = TestClient(app)  # , raise_server_exceptions=False)
     return client
 
 

--- a/tests/test_routes/test_item.py
+++ b/tests/test_routes/test_item.py
@@ -1,7 +1,6 @@
 from typing import Dict
 
 import pytest
-from conftest import model_to_dict
 from fastapi.testclient import TestClient
 from sqlalchemy import desc
 from starlette import status
@@ -9,6 +8,7 @@ from starlette import status
 from rental_backend.__main__ import app
 from rental_backend.models.db import Item
 from rental_backend.routes.item import item
+from tests.conftest import model_to_dict, make_url_query
 
 
 client = TestClient(app)

--- a/tests/test_routes/test_item.py
+++ b/tests/test_routes/test_item.py
@@ -8,7 +8,7 @@ from starlette import status
 from rental_backend.__main__ import app
 from rental_backend.models.db import Item
 from rental_backend.routes.item import item
-from tests.conftest import model_to_dict, make_url_query
+from tests.conftest import make_url_query, model_to_dict
 
 
 client = TestClient(app)

--- a/tests/test_routes/test_item_type.py
+++ b/tests/test_routes/test_item_type.py
@@ -1,10 +1,10 @@
 import pytest
-from conftest import model_to_dict
 from sqlalchemy import desc
 from starlette import status
 
 from rental_backend.models.db import ItemType
 from rental_backend.routes.item_type import item_type
+from tests.conftest import model_to_dict
 
 
 # New fixtures for itemtype tests

--- a/tests/test_routes/test_rental_session.py
+++ b/tests/test_routes/test_rental_session.py
@@ -1,0 +1,337 @@
+from typing import Tuple, List, Generator
+import datetime
+
+import pytest
+from starlette import status
+from sqlalchemy.exc import StatementError, DataError
+from sqlalchemy import desc
+
+from rental_backend.models.base import BaseDbModel
+from rental_backend.models.db import Item, RentalSession, ItemType, Event
+from rental_backend.routes.rental_session import rental_session
+from rental_backend.schemas.models import RentStatus
+from conftest import model_to_dict
+# TODO: подумать над багом при teardown test: при ошибке в teardown (точно, если sqlalchemy), у меня не затираются тестовые объекты => некритично, но желательно починить!
+
+# New fixtures
+@pytest.fixture()
+def expire_mock(mocker):
+    """Mock-объект для функции check_session_expiration."""
+    fake_check = mocker.patch('rental_backend.routes.rental_session.check_session_expiration')
+    fake_check.return_value = True
+    return fake_check
+
+
+@pytest.fixture
+def expiration_time_mock(mocker):
+    """Мок для RENTAL_SESSION_EXPIRY, чтобы не ждать в ходе тестов."""
+    fast_expiration = mocker.patch('rental_backend.routes.rental_session.RENTAL_SESSION_EXPIRY', new=datetime.timedelta(seconds=2))
+    return fast_expiration
+
+
+@pytest.fixture
+def item_types(dbsession) -> List[ItemType]:
+    """Создает 2 itemType в БД и возвращает их."""
+    itemtypes = []
+    for ind in range(2):
+        itemtypes.append(
+            ItemType.create(session=dbsession, name=f'Test ItemType {ind}')
+        )
+    dbsession.commit()
+    return itemtypes
+
+
+@pytest.fixture
+def items_with_same_type(dbsession, item_types) -> List[Item]:
+    """Создает 2 Item с одним itemType в БД и возвращает их."""
+    items = []
+    for _ in range(2):
+        items.append(
+            Item.create(session=dbsession, type_id=item_types[0].id)
+        )
+    dbsession.commit()
+    return items
+
+
+@pytest.fixture
+def items_with_diff_types(dbsession, item_types) -> List[Item]:
+    """Создает 2 Item с разными itemType в БД и возвращает их."""
+    items = []
+    for ind in range(2):
+        items.append(
+            Item.create(session=dbsession, type_id=item_types[ind].id)
+        )
+    dbsession.commit()
+    return items
+
+
+@pytest.fixture
+def base_rentses_url(base_test_url: str) -> str:
+    """Формирует корневой URL для Item."""
+    return f'{base_test_url}{rental_session.prefix}'
+
+
+@pytest.fixture
+def available_item(dbsession, item_fixture):
+    """Item, доступный для аренды.
+
+    .. note::
+        Очистка производится в dbsession.
+    """
+    if item_fixture.is_available == False:
+        Item.update(item_fixture.id, session=dbsession, is_available=True)
+        dbsession.refresh(item_fixture)
+        dbsession.commit()
+    return item_fixture
+
+
+@pytest.fixture
+def nonavailable_item(dbsession, item_fixture):
+    """Item, не доступный для аренды.
+
+    .. note::
+        Очистка производится в dbsession.
+    """
+    if item_fixture.is_available == True:
+        Item.update(item_fixture.id, session=dbsession, is_available=False)
+        dbsession.refresh(item_fixture)
+        dbsession.commit()
+    return item_fixture
+
+
+@pytest.fixture
+def rentses(dbsession, available_item, authlib_user):
+    """Экземпляр RentalSession, создаваемый в POST /rental_session.
+
+    .. note::
+        Очистка происходит в dbsession.
+    """
+    rent = RentalSession.create(
+        session=dbsession,
+        user_id=authlib_user.get("id"),
+        item_id=available_item.id,
+        reservation_ts=datetime.datetime.now(tz=datetime.timezone.utc),
+        status=RentStatus.RESERVED,
+    )
+    dbsession.add(rent)
+    dbsession.commit()
+    return rent
+
+
+# Subtests (not call directly by pytest.)
+def check_object_creation(db_model: BaseDbModel, session, num_of_creations: int=1) -> Generator[None, None, None]:
+    """Проверяет создание объекта в БД после события."""
+    start_len = db_model.query(session=session).count()
+    yield
+    end_len = db_model.query(session=session).count()
+    assert (end_len - start_len) == num_of_creations, f'Убедитесь, что создается {num_of_creations} объектов {db_model} в БД!'
+
+# TODO: Разбить тесты на блоки: по блоку на каждую ручку.
+
+# def check_expiration_call(func_mock, session_id):  # TODO: Думаю, все же избыточно тестить каждую строчку кода. Только входное и выходное.
+#     """Проверяет, что функция check_session_expiration вызывается 1 раз."""
+#     try:
+#         func_mock.assert_called_once_with(session_id)
+#     except AssertionError:
+#         raise NotImplementedError('Убедитесь, что функция check_session_expiration вызывается при вызове хэндлера!')
+
+
+# Tests for POST /rental_session
+def test_create_with_avail_item(dbsession, client, available_item, base_rentses_url, expire_mock):
+    """Проверка логики метода с исходно доступным предметом в БД."""
+    check_creation = check_object_creation(RentalSession, dbsession)  # TODO: Мб переписать как контекстный менеджер? Типа этот check же в контекст события...
+    next(check_creation)
+    response = client.post(f'{base_rentses_url}/{available_item.type_id}')
+    assert response.status_code == status.HTTP_200_OK
+    next(check_creation, None)
+    dbsession.refresh(available_item)
+    assert available_item.is_available == False, 'Убедитесь, что Item становится недоступен для аренды после создания RentalSession с ним!'
+
+
+def test_create_with_no_avail_item(dbsession, client, nonavailable_item, base_rentses_url, expire_mock):
+    """Проверка логики метода без исходно доступных предметов."""
+    check_creation = check_object_creation(RentalSession, dbsession, num_of_creations=0)
+    next(check_creation)
+    response = client.post(f'{base_rentses_url}/{nonavailable_item.type_id}')
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    next(check_creation, None)
+    dbsession.refresh(nonavailable_item)
+    assert nonavailable_item.is_available == False, 'Убедитесь, что Item остается недоступен для аренды!'
+
+
+def test_create_with_unexisting_id(dbsession, client, base_rentses_url, expire_mock):
+    """Проверка логики метода с несуществующим item_type_id."""
+    check_creation = check_object_creation(RentalSession, dbsession, num_of_creations=0)
+    next(check_creation)
+    try:
+        unexisting_type_id = ItemType.query(session=dbsession).order_by(desc('id'))[0].id + 1
+    except IndexError:
+        unexisting_type_id = 1
+    response = client.post(f'{base_rentses_url}/{unexisting_type_id}')
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    next(check_creation, None)
+
+
+@pytest.mark.parametrize(
+        'invalid_itemtype_id, right_status_code',
+        [
+            ('hihi', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('ha-ha', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('he-he/hoho', status.HTTP_404_NOT_FOUND),
+            (-1, status.HTTP_404_NOT_FOUND),
+            ('', status.HTTP_405_METHOD_NOT_ALLOWED)],
+        ids= ['text', 'hyphen', 'trailing_slash', 'negative_num', 'empty'],
+)
+def test_create_with_invalid_id(dbsession, client, base_rentses_url, expire_mock, invalid_itemtype_id, right_status_code):
+    """Проверка логики метода с невалидным item_type_id."""
+    check_creation = check_object_creation(RentalSession, dbsession, num_of_creations=0)
+    next(check_creation)
+    response = client.post(f'{base_rentses_url}/{invalid_itemtype_id}')
+    if response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
+        pytest.xfail(reason='Ждет issue #40. Удалить маркер и проверить работоспособность.')
+    assert response.status_code == right_status_code
+    next(check_creation, None)
+
+
+def test_create_internal_server_error(monkeypatch, client, available_item, base_rentses_url):
+    """Проверка логики обработки неожиданных ошибок."""
+    def mock_db_error(*args, **kwargs):
+        raise Exception("Database error")
+
+    monkeypatch.setattr("rental_backend.routes.rental_session.Item.query", mock_db_error)
+    response = client.post(f"{base_rentses_url}/{available_item.type_id}")
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
+def test_create_and_expire(dbsession, client, base_rentses_url, available_item, expiration_time_mock):
+    """Проверка правильного срабатывания check_session_expiration."""
+    response = client.post(f'{base_rentses_url}/{available_item.type_id}')
+    assert response.status_code == status.HTTP_200_OK
+    assert RentalSession.get(id=response.json()['id'], session=dbsession).status == RentStatus.CANCELED, 'Убедитесь, что по истечение RENTAL_SESSION_EXPIRY, аренда переходит в RentStatus.RESERVED!'
+
+
+
+# Tests for PATCH /rental_session
+# @pytest.mark.skip(reason='Пока что не до них')
+@pytest.mark.parametrize(
+    'payload, right_status_code, update_in_db',
+    [
+        (
+            {
+                "status": "reserved",
+                "end_ts": "2025-04-18T23:32:30.589Z",
+                "actual_return_ts": "2025-04-18T23:32:30.589Z",
+                "admin_close_id": 0,
+            },
+            status.HTTP_200_OK, True,
+        ),
+        (
+            {"end_ts": "2025-04-18T23:32:30.589Z", "actual_return_ts": "2025-04-18T23:32:30.589Z", "admin_close_id": 0},
+            status.HTTP_200_OK, True,
+        ),
+        (
+            {"status": "reserved", "actual_return_ts": "2025-04-18T23:32:30.589Z", "admin_close_id": 0},
+            status.HTTP_200_OK, True,
+        ),
+        ({"status": "reserved", "end_ts": "2025-04-18T23:32:30.589Z", "admin_close_id": 0}, status.HTTP_200_OK, True,),
+        (
+            {
+                "status": "reserved",
+                "end_ts": "2025-04-18T23:32:30.589Z",
+                "actual_return_ts": "2025-04-18T23:32:30.589Z",
+            },
+            status.HTTP_200_OK, True,
+        ),
+        (
+            {
+                "status": "reserved",
+                "end_ts": "2025-04-18T23:32:30.589Z",
+                "actual_return_ts": "2025-04-18T23:32:30.589Z",
+                "admin_close_id": 0,
+                "extra": "oops!",
+            },
+            status.HTTP_200_OK, True,
+        ),
+        (
+            {
+                "status": "cringe",
+                "end_ts": "2025-04-18T23:32:30.589Z",
+                "actual_return_ts": "2025-04-18T23:32:30.589Z",
+                "admin_close_id": 0,
+            },
+            status.HTTP_422_UNPROCESSABLE_ENTITY, False,
+        ),
+        (
+            {
+                "status": "reserved",
+                "end_ts": "he-he",
+                "actual_return_ts": "2025-04-18T23:32:30.589Z",
+                "admin_close_id": 0,
+            },
+            status.HTTP_422_UNPROCESSABLE_ENTITY, False,
+        ),
+        (
+            {
+                "status": "reserved",
+                "end_ts": "2025-04-18T23:32:30.589Z",
+                "actual_return_ts": "ha-ha",
+                "admin_close_id": 0,
+            },
+            status.HTTP_422_UNPROCESSABLE_ENTITY, False,
+        ),
+        (
+            {
+                "status": "reserved",
+                "end_ts": "2025-04-18T23:32:30.589Z",
+                "actual_return_ts": "2025-04-18T23:32:30.589Z",
+                "admin_close_id": "boba",
+            },
+            status.HTTP_422_UNPROCESSABLE_ENTITY, False,
+        ),
+        ({}, status.HTTP_409_CONFLICT, False,),
+        (
+            {"status": "reserved", "end_ts": None, "actual_return_ts": None, "admin_close_id": None},
+            status.HTTP_409_CONFLICT, False,
+        ),
+        (
+            {
+                "status": "reserved",
+                "end_ts": "2025-04-18T23:32:30.589Z",
+                "actual_return_ts": None,
+                "admin_close_id": None,
+            },
+            status.HTTP_200_OK, True,
+        ),
+    ],
+    ids=[
+        'valid_new_payload',
+        'valid_new_without_status',
+        'valid_new_without_end_ts',
+        'valid_new_without_actual_return_ts',
+        'valid_new_without_admin_close_id',
+        'valid_new_with_extra_field',
+        'invalid_status',
+        'invalid_end_ts',
+        'inavalid_actual_return_ts',
+        'invalid_admin_close_id',
+        'empty_payload',
+        'full_old_payload',
+        'part_old_payload',
+    ],
+)
+def test_payload_for_update_rental_session(
+    dbsession, rentses, client, base_rentses_url, payload, right_status_code, update_in_db
+):
+    """Проверка ручки PATCH /itemtype на разные входные данные.
+    
+    Проверяются HTTP-коды и состояние записи в БД.
+    """
+    old_model_fields = model_to_dict(rentses)
+    response = client.patch(f"{base_rentses_url}/{rentses.id}", json=payload)
+    if response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
+        pytest.xfail(reason='Ждут issue #39. Удалить маркер, когда баг будет устранен.')
+    assert response.status_code == right_status_code
+    dbsession.refresh(rentses)
+    new_model_fields = model_to_dict(rentses)
+    is_really_updated = old_model_fields != new_model_fields
+    assert is_really_updated == update_in_db

--- a/tests/test_routes/test_rental_session.py
+++ b/tests/test_routes/test_rental_session.py
@@ -390,25 +390,27 @@ def test_return_with_set_end_ts(dbsession, client, base_rentses_url, rentses_wit
 
 
 # Tests for GET /rental_session/user/{user_id}
-# @pytest.mark.parametrize(
-#         'user_id, right_status_code',
-#         [
-#             ('hihi', status.HTTP_422_UNPROCESSABLE_ENTITY),
-#             ('ha-ha', status.HTTP_422_UNPROCESSABLE_ENTITY),
-#             ('he-he/hoho', status.HTTP_404_NOT_FOUND),
-#             (-1, status.HTTP_404_NOT_FOUND),
-#             ('', status.HTTP_404_NOT_FOUND)
-#         ],
-#         ids= ['text', 'hyphen', 'trailing_slash', 'negative_num', 'empty'],
-# )
-# def test_get_for_user_with_invalid_id(dbsession, client, base_rentses_url, rentses, user_id, right_status_code):
-#     """Проверка логики метода с невалидным user_id."""
-#     response = client.patch(f'{base_rentses_url}/user/{user_id}')
-#     if response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
-#         pytest.xfail(reason='Ждет issue #40. Удалить маркер и проверить работоспособность.')
-#     assert response.status_code == right_status_code
-#     dbsession.refresh(rentses)
-#     assert rentses.status != RentStatus.ACTIVE, 'Убедитесь, что при невалидном запросе сессия не переводится в RentStatus.ACTIVE!'
+@pytest.mark.parametrize(
+        'user_id, right_status_code',
+        [
+            ('hihi', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('ha-ha', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('he-he/hoho', status.HTTP_404_NOT_FOUND),
+            (-1, status.HTTP_200_OK),
+            ('', status.HTTP_422_UNPROCESSABLE_ENTITY)
+        ],
+        ids= ['text', 'hyphen', 'trailing_slash', 'negative_num', 'empty'],
+)
+def test_get_for_user_with_invalid_id(dbsession, client, base_rentses_url, rentses, user_id, right_status_code):
+    """Проверка логики метода с невалидным user_id."""
+    response = client.get(f'{base_rentses_url}/user/{user_id}')
+    if response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
+        pytest.xfail(reason='Ждет issue #40. Удалить маркер и проверить работоспособность.')
+    assert response.status_code == right_status_code
+    if right_status_code == status.HTTP_200_OK:
+        returned_queue = response.json()
+        assert isinstance(returned_queue, list), 'Убедитесь, что возвращаемый объект типа List!'
+        assert len(returned_queue) == 0, 'Убедитесь, что при передаче невалидного user_id возвращается пустой список.'
 
 
 # Tests for PATCH /rental_session/{session_id}

--- a/tests/test_routes/test_rental_session.py
+++ b/tests/test_routes/test_rental_session.py
@@ -1,7 +1,6 @@
 from typing import Tuple, List, Generator, Dict, Any
 import datetime
 from contextlib import contextmanager
-# import pdb
 
 import pytest
 from starlette import status

--- a/tests/test_routes/test_rental_session.py
+++ b/tests/test_routes/test_rental_session.py
@@ -13,20 +13,8 @@ from rental_backend.models.db import Item, RentalSession, ItemType, Event, Strik
 from rental_backend.routes.rental_session import rental_session
 from rental_backend.schemas.models import RentStatus
 from rental_backend.exceptions import AlreadyExists
-from conftest import model_to_dict
+from tests.conftest import model_to_dict, make_url_query
 # TODO: подумать над багом при teardown test: при ошибке в teardown (точно, если sqlalchemy), у меня не затираются тестовые объекты => некритично, но желательно починить!
-
-
-def make_url_query(data: Dict) -> str:
-    """Вспомогательная функция для преобразования входных данных
-    в строку параметров URL.
-    """
-    if len(data) == 0:
-        return ''
-    if len(data) == 1:
-        for k in data:
-            return f'?{k}={data[k]}'
-    return '?' + '&'.join(f'{k}={data[k]}' for k in data)
 
 
 # New fixtures

--- a/tests/test_routes/test_rental_session.py
+++ b/tests/test_routes/test_rental_session.py
@@ -1,5 +1,7 @@
-from typing import Tuple, List, Generator, Dict
+from typing import Tuple, List, Generator, Dict, Any
 import datetime
+from contextlib import contextmanager
+# import pdb
 
 import pytest
 from starlette import status
@@ -86,7 +88,7 @@ def base_rentses_url(base_test_url: str) -> str:
 
 
 @pytest.fixture
-def available_item(dbsession, item_fixture):
+def available_item(dbsession, item_fixture) -> Item:
     """Item, доступный для аренды.
 
     .. note::
@@ -100,7 +102,7 @@ def available_item(dbsession, item_fixture):
 
 
 @pytest.fixture
-def nonavailable_item(dbsession, item_fixture):
+def nonavailable_item(dbsession, item_fixture) -> Item:
     """Item, не доступный для аренды.
 
     .. note::
@@ -114,7 +116,18 @@ def nonavailable_item(dbsession, item_fixture):
 
 
 @pytest.fixture
-def rentses(dbsession, available_item, authlib_user):
+def valid_update_payload() -> Dict[str, Any]:
+    """Валидный словарь параметров для обновления RentalSession."""
+    return {
+        "status": "reserved",
+        "end_ts": "2025-04-18T23:32:30.589Z",
+        "actual_return_ts": "2025-04-18T23:32:30.589Z",
+        "admin_close_id": 0,
+    }
+
+
+@pytest.fixture
+def rentses(dbsession, available_item, authlib_user) -> RentalSession:
     """Экземпляр RentalSession, создаваемый в POST /rental_session.
 
     .. note::
@@ -127,13 +140,31 @@ def rentses(dbsession, available_item, authlib_user):
         reservation_ts=datetime.datetime.now(tz=datetime.timezone.utc),
         status=RentStatus.RESERVED,
     )
+    Item.update(id=available_item.id, session=dbsession, is_available=False)
     dbsession.add(rent)
     dbsession.commit()
     return rent
 
 
 @pytest.fixture
-def active_rentses(dbsession, rentses):
+def another_rentses(dbsession, items_with_same_type, another_authlib_user) -> RentalSession:
+    """Еще один экземпляр RentalSession с отличающимся пользователем."""
+    renting_item = items_with_same_type[0]
+    rent = RentalSession.create(
+        session=dbsession,
+        user_id=another_authlib_user.get("id"),
+        item_id=renting_item.id,
+        reservation_ts=datetime.datetime.now(tz=datetime.timezone.utc),
+        status=RentStatus.RESERVED,
+    )
+    Item.update(id=renting_item.id, session=dbsession, is_available=False)
+    dbsession.add(rent)
+    dbsession.commit()
+    return rent
+
+
+@pytest.fixture
+def active_rentses(dbsession, rentses) -> RentalSession:
     """Начатая сессия аренды."""
     try:
         RentalSession.update(id=rentses.id, session=dbsession, status=RentStatus.ACTIVE)
@@ -144,14 +175,15 @@ def active_rentses(dbsession, rentses):
 
 
 @pytest.fixture
-def rentses_with_end_ts(dbsession, rentses):
+def rentses_with_end_ts(dbsession, active_rentses) -> RentalSession:
     """RentalSession с end_ts не None."""
-    RentalSession.update(id=rentses.id, session=dbsession, end_ts=datetime.datetime.now(tz=datetime.timezone.utc))
+    RentalSession.update(id=active_rentses.id, session=dbsession, end_ts=datetime.datetime.now(tz=datetime.timezone.utc))
     dbsession.commit()
-    return rentses
+    return active_rentses
 
 
 # Subtests (not call directly by pytest.)
+@contextmanager
 def check_object_creation(db_model: BaseDbModel, session, num_of_creations: int=1) -> Generator[None, None, None]:
     """Проверяет создание объекта в БД после события."""
     start_len = db_model.query(session=session).count()
@@ -159,50 +191,39 @@ def check_object_creation(db_model: BaseDbModel, session, num_of_creations: int=
     end_len = db_model.query(session=session).count()
     assert (end_len - start_len) == num_of_creations, f'Убедитесь, что создается {num_of_creations} объектов {db_model.__name__} в БД!'
 
-# TODO: Разбить тесты на блоки: по блоку на каждую ручку.
 
-# def check_expiration_call(func_mock, session_id):  # TODO: Думаю, все же избыточно тестить каждую строчку кода. Только входное и выходное.
-#     """Проверяет, что функция check_session_expiration вызывается 1 раз."""
-#     try:
-#         func_mock.assert_called_once_with(session_id)
-#     except AssertionError:
-#         raise NotImplementedError('Убедитесь, что функция check_session_expiration вызывается при вызове хэндлера!')
+# def check_object_update():  # TODO: написать и протестить в тестах
+#     """Проверяет обновление объекта в БД после события."""
 
 
-# Tests for POST /rental_session/{item_type_id}
+# Tests for POST /rental-sessions/{item_type_id}
 def test_create_with_avail_item(dbsession, client, available_item, base_rentses_url, expire_mock):
     """Проверка логики метода с исходно доступным предметом в БД."""
-    check_creation = check_object_creation(RentalSession, dbsession)  # TODO: Мб переписать как контекстный менеджер? Типа этот check же в контекст события...
-    next(check_creation)
-    response = client.post(f'{base_rentses_url}/{available_item.type_id}')
-    assert response.status_code == status.HTTP_200_OK
-    next(check_creation, None)
+    with check_object_creation(RentalSession, dbsession):
+        response = client.post(f'{base_rentses_url}/{available_item.type_id}')
+        assert response.status_code == status.HTTP_200_OK
     dbsession.refresh(available_item)
     assert available_item.is_available == False, 'Убедитесь, что Item становится недоступен для аренды после создания RentalSession с ним!'
 
 
 def test_create_with_no_avail_item(dbsession, client, nonavailable_item, base_rentses_url, expire_mock):
     """Проверка логики метода без исходно доступных предметов."""
-    check_creation = check_object_creation(RentalSession, dbsession, num_of_creations=0)
-    next(check_creation)
-    response = client.post(f'{base_rentses_url}/{nonavailable_item.type_id}')
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    next(check_creation, None)
+    with check_object_creation(RentalSession, dbsession, num_of_creations=0):
+        response = client.post(f'{base_rentses_url}/{nonavailable_item.type_id}')
+        assert response.status_code == status.HTTP_404_NOT_FOUND
     dbsession.refresh(nonavailable_item)
     assert nonavailable_item.is_available == False, 'Убедитесь, что Item остается недоступен для аренды!'
 
 
 def test_create_with_unexisting_id(dbsession, client, base_rentses_url, expire_mock):
     """Проверка логики метода с несуществующим item_type_id."""
-    check_creation = check_object_creation(RentalSession, dbsession, num_of_creations=0)
-    next(check_creation)
     try:
         unexisting_type_id = ItemType.query(session=dbsession).order_by(desc('id'))[0].id + 1
     except IndexError:
         unexisting_type_id = 1
-    response = client.post(f'{base_rentses_url}/{unexisting_type_id}')
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    next(check_creation, None)
+    with check_object_creation(RentalSession, dbsession, num_of_creations=0):
+        response = client.post(f'{base_rentses_url}/{unexisting_type_id}')
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.parametrize(
@@ -217,13 +238,11 @@ def test_create_with_unexisting_id(dbsession, client, base_rentses_url, expire_m
 )
 def test_create_with_invalid_id(dbsession, client, base_rentses_url, expire_mock, invalid_itemtype_id, right_status_code):
     """Проверка логики метода с невалидным item_type_id."""
-    check_creation = check_object_creation(RentalSession, dbsession, num_of_creations=0)
-    next(check_creation)
-    response = client.post(f'{base_rentses_url}/{invalid_itemtype_id}')
-    if response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
-        pytest.xfail(reason='Ждет issue #40. Удалить маркер и проверить работоспособность.')
-    assert response.status_code == right_status_code
-    next(check_creation, None)
+    with check_object_creation(RentalSession, dbsession, num_of_creations=0)
+        response = client.post(f'{base_rentses_url}/{invalid_itemtype_id}')
+        if response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
+            pytest.xfail(reason='Ждет issue #40. Удалить маркер и проверить работоспособность.')
+        assert response.status_code == right_status_code
 
 
 def test_create_internal_server_error(monkeypatch, dbsession, client, available_item, base_rentses_url):
@@ -246,7 +265,7 @@ def test_create_and_expire(dbsession, client, base_rentses_url, available_item, 
     assert RentalSession.get(id=response.json()['id'], session=dbsession).status == RentStatus.CANCELED, 'Убедитесь, что по истечение RENTAL_SESSION_EXPIRY, аренда переходит в RentStatus.RESERVED!'
 
 
-# Tests for PATCH /rental_session/{session_id}/start
+# Tests for PATCH /rental-sessions/{session_id}/start
 def test_start_success(dbsession, client, rentses, base_rentses_url):
     """Проверка логики метода с успешным стартом аренды."""
     # check_creation = check_object_creation(RentalSession, dbsession)  # TODO: Мб переписать как контекстный менеджер? Типа этот check же в контекст события...
@@ -293,7 +312,7 @@ def test_start_with_unexisting_session(dbsession, client, base_rentses_url, rent
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-# Tests for PATCH /rental_session/{session_id}/return
+# Tests for PATCH /rental-sessions/{session_id}/return
 def test_return_success(dbsession, client, active_rentses, base_rentses_url):
     """Проверка логики метода с успешным окончанием аренды."""
     # check_creation = check_object_creation(RentalSession, dbsession)  # TODO: Мб переписать как контекстный менеджер? Типа этот check же в контекст события...
@@ -378,7 +397,7 @@ def test_return_with_strike(dbsession, client, base_rentses_url, active_rentses,
     strike_query = make_url_query(query_dict)
     response = client.patch(f'{base_rentses_url}/{active_rentses.id}/return{strike_query}')
     assert response.status_code == right_status_code
-    next(check_creation, None)  # FIXME: Проверить, как станет известно по добавлению await к create_strike.
+    next(check_creation, None)
 
 
 def test_return_with_set_end_ts(dbsession, client, base_rentses_url, rentses_with_end_ts):
@@ -390,7 +409,14 @@ def test_return_with_set_end_ts(dbsession, client, base_rentses_url, rentses_wit
     assert rentses_with_end_ts.end_ts == old_end_ts, 'Убедитесь, что при завершении аренды end_ts не меняется, если он не был None!'
 
 
-# Tests for GET /rental_session/user/{user_id}
+# Tests for GET /rental-sessions/user/{user_id}
+def test_get_for_user_success(dbsession, client, base_rentses_url, rentses):
+    """Попытка успешно получить список аренд пользователя."""
+    response = client.get(f'{base_rentses_url}/user/{rentses.user_id}')
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()) == len(RentalSession.query(session=dbsession).filter(RentalSession.user_id == rentses.user_id).all()), 'Убедитесь, что возвращаются все аренды пользователя!'
+
+
 @pytest.mark.parametrize(
         'user_id, right_status_code',
         [
@@ -414,9 +440,55 @@ def test_get_for_user_with_invalid_id(dbsession, client, base_rentses_url, rents
         assert len(returned_queue) == 0, 'Убедитесь, что при передаче невалидного user_id возвращается пустой список.'
 
 
-# Tests for PATCH /rental_session/{session_id}
-# TODO: добавить сюда тесты с невалидными URL + HTTP_500.
-@pytest.mark.skip(reason='Пока что не до них')
+def test_get_for_user_internal_server_error(monkeypatch, client, base_rentses_url, rentses):
+    """Проверяет поведение хэндлера при появлении непредвиденной ошибки."""
+    def mock_db_error(*args, **kwargs):
+        raise Exception("Database error")
+
+    monkeypatch.setattr("rental_backend.routes.rental_session.RentalSession.query", mock_db_error)
+    response = client.get(f'{base_rentses_url}/user/{rentses.user_id}')
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
+# Tests for GET /rental-sessions/{session_id}
+def test_retrieve_success(dbsession, client, base_rentses_url, rentses):
+    """Проверяем успешное получение сессии аренды."""
+    response = client.get(f'{base_rentses_url}/{rentses.id}')
+    assert response.status_code == status.HTTP_200_OK
+    assert rentses == RentalSession.get(id=response.json()['id'], session=dbsession)
+
+@pytest.mark.xfail(reason='Ждет issue #40. Потом удалить маркер и проверить тесты.')
+@pytest.mark.parametrize(
+        'session_id, right_status_code',
+        [
+            ('hihi', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('ha-ha', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('he-he/hoho', status.HTTP_404_NOT_FOUND),
+            (-1, status.HTTP_200_OK),
+            ('', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('-1?hoho=hihi', status.HTTP_422_UNPROCESSABLE_ENTITY)
+        ],
+        ids= ['text', 'hyphen', 'trailing_slash', 'negative_num', 'empty', 'excess_query'],
+)
+def test_retrieve_invalid_id(dbsession, client, base_rentses_url, rentses, session_id, right_status_code):
+    """Проверка получения сессии по невалидному URL-path."""
+    response = client.get(f'{base_rentses_url}/{rentses.id}')
+    assert response.status_code == right_status_code
+    if right_status_code == status.HTTP_200_OK:
+        assert response.json()['id'] == rentses.id, 'Убедитесь, что возвращается та же сессия, что и запрашивается!'
+
+
+def test_retrieve_internal_server_error(monkeypatch, client, base_rentses_url, rentses):
+    """Проверяет поведение хэндлера при появлении непредвиденной ошибки."""
+    def mock_db_error(*args, **kwargs):
+        raise Exception("Database error")
+
+    monkeypatch.setattr("rental_backend.routes.rental_session.RentalSession.get", mock_db_error)
+    response = client.get(f'{base_rentses_url}/{rentses.id}')
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
+# Tests for PATCH /rental-sessions/{session_id}
 @pytest.mark.parametrize(
     'payload, right_status_code, update_in_db',
     [
@@ -523,13 +595,10 @@ def test_get_for_user_with_invalid_id(dbsession, client, base_rentses_url, rents
         'part_old_payload',
     ],
 )
-def test_payload_for_update_rental_session(
+def test_update_payload(
     dbsession, rentses, client, base_rentses_url, payload, right_status_code, update_in_db
 ):
-    """Проверка ручки PATCH /itemtype на разные входные данные.
-    
-    Проверяются HTTP-коды и состояние записи в БД.
-    """
+    """Проверка поведения при разном теле запроса."""
     old_model_fields = model_to_dict(rentses)
     response = client.patch(f"{base_rentses_url}/{rentses.id}", json=payload)
     if response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
@@ -539,3 +608,168 @@ def test_payload_for_update_rental_session(
     new_model_fields = model_to_dict(rentses)
     is_really_updated = old_model_fields != new_model_fields
     assert is_really_updated == update_in_db
+
+
+@pytest.mark.parametrize(
+        'session_id, right_status_code',
+        [
+            ('hihi', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('ha-ha', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('he-he/hoho', status.HTTP_404_NOT_FOUND),
+            (-1, status.HTTP_404_NOT_FOUND),
+            ('', status.HTTP_405_METHOD_NOT_ALLOWED),
+            ('-1?hoho=hihi', status.HTTP_404_NOT_FOUND)
+        ],
+        ids= ['text', 'hyphen', 'trailing_slash', 'negative_num', 'empty', 'excess_query'],
+)
+def test_update_invalid_id(dbsession, client, base_rentses_url, rentses, valid_update_payload, session_id, right_status_code):
+    """Проверка получения сессии по невалидному URL-path."""
+    response = client.patch(f'{base_rentses_url}/{session_id}', json=valid_update_payload)
+    assert response.status_code == right_status_code
+
+
+def test_update_internal_server_error(mocker, client, base_rentses_url, rentses, valid_update_payload):
+    """Проверяет поведение хэндлера при появлении непредвиденной ошибки."""
+    # def mock_db_error(*args, **kwargs):
+    #     raise Exception("Database error")
+
+    error_func = mocker.patch("rental_backend.routes.rental_session.RentalSession.get", side_effect=Exception('Database error'))
+    # pdb.set_trace()
+    response = client.patch(f'{base_rentses_url}/{rentses.id}', json=valid_update_payload)
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR  # TODO: также добавить такую (и в остальных местах) проверку вызова мок-объекта (что падает именно из-за него).
+    assert error_func.call_count == 1, 'Убедитесь, что ошибка выпадает именно при попытке вызвать RentalSession.get!'
+
+
+# Tests for GET /rental-sessions
+@pytest.mark.parametrize(
+    'is_reserved, is_canceled, is_dismissed, is_overdue, is_returned, is_active, right_status_code',
+    [
+        (True, True, True, True, True, True, status.HTTP_200_OK),
+        (None, True, True, True, True, True, status.HTTP_200_OK),
+        (True, None, True, True, True, True, status.HTTP_200_OK),
+        (True, True, None, True, True, True, status.HTTP_200_OK),
+        (True, True, True, None, True, True, status.HTTP_200_OK),
+        (True, True, True, True, None, True, status.HTTP_200_OK),
+        (True, True, True, True, True, None, status.HTTP_200_OK),
+        ('haha', True, True, True, True, True, status.HTTP_422_UNPROCESSABLE_ENTITY),  # FIXME: жду ответа про адекватность поведения (1 -> True)
+        (True, '', True, True, True, True, status.HTTP_422_UNPROCESSABLE_ENTITY),
+        (True, True, -1, True, True, True, status.HTTP_422_UNPROCESSABLE_ENTITY),
+        (True, True, True, 4, True, True, status.HTTP_422_UNPROCESSABLE_ENTITY),
+        (True, True, True, True, 5, True, status.HTTP_422_UNPROCESSABLE_ENTITY),
+        (True, True, True, True, True, 6, status.HTTP_422_UNPROCESSABLE_ENTITY),
+        (None, None, None, None, None, None, status.HTTP_200_OK),
+        (False, False, False, False, False, False, status.HTTP_200_OK),
+    ],
+    ids=[
+        'valid_all',
+        'valid_without_is_reserved',
+        'valid_without_is_canceled',
+        'valid_without_is_dismissed',
+        'valid_without_is_overdue',
+        'valid_without_is_returned',
+        'valid_without_is_active',
+        'invalid_is_reserved',
+        'invalid_is_canceled',
+        'invalid_is_dismissed',
+        'invalid_is_overdue',
+        'invalid_is_returned',
+        'invalid_is_active',
+        'valid_empty',
+        'valid_all_False',
+    ],
+)
+def test_get_url_query(dbsession, client, base_rentses_url, rentses, is_reserved, is_canceled, is_dismissed, is_overdue, is_returned, is_active, right_status_code):
+    """Проверка получения сессий при разных URL-query."""
+    query_data = dict()
+    if is_reserved is not None:
+        query_data['is_reserved'] = is_reserved
+    if is_canceled is not None:
+        query_data['is_canceled'] = is_canceled
+    if is_dismissed is not None:
+        query_data['is_dismissed'] = is_dismissed
+    if is_overdue is not None:
+        query_data['is_overdue'] = is_overdue
+    if is_returned is not None:
+        query_data['is_returned'] = is_returned
+    if is_active is not None:
+        query_data['is_active'] = is_active
+    print(query_data)
+    # pdb.set_trace()
+    response = client.get(f'{base_rentses_url}{make_url_query(query_data)}')
+    assert response.status_code == right_status_code
+
+
+def test_get_query_extra_param(dbsession, client, base_rentses_url, rentses):
+    """Проверка запроса с непредусмотренным параметром в URL-query."""
+    extra_response = client.get(f'{base_rentses_url}?hehe=True')
+    assert extra_response.status_code == status.HTTP_200_OK
+    valid_response = client.get(f'{base_rentses_url}')
+    assert len(extra_response.json()) == len(valid_response.json()), 'Убедитесь, что экстра параметр не меняет поведения хэндлера!'
+
+
+# Tests for DELETE /rental-sessions/{session_id}/cancel
+# TODO: теперь пишем тесты здесь :)
+def test_cancel_success(dbsession, client, base_rentses_url, rentses):
+    """Проверяет успешный сценарий отмены аренды."""
+    print()
+    response = client.delete(f'{base_rentses_url}/{rentses.id}/cancel')
+    assert response.status_code == status.HTTP_200_OK, 'Убедитесь, что аренду можно отменить!'
+    dbsession.refresh(rentses)
+    assert rentses.status == RentStatus.CANCELED, 'Убедитесь, что аренда переводится в статус RentStatus.CANCELED!'
+    assert Item.get(id=rentses.item_id, session=dbsession).is_available == True, 'Убедитесь, что Item становится доступен для повторной аренды!'
+
+
+@pytest.mark.parametrize(
+        'session_id, right_status_code',
+        [
+            ('hihi', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('ha-ha', status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('he-he/hoho', status.HTTP_404_NOT_FOUND),
+            (-1, status.HTTP_404_NOT_FOUND),
+            ('', status.HTTP_404_NOT_FOUND),
+            ('-1?hoho=hihi', status.HTTP_405_METHOD_NOT_ALLOWED)
+        ],
+        ids= ['text', 'hyphen', 'trailing_slash', 'negative_num', 'empty', 'excess_query'],
+)
+def test_cancel_invalid(client, base_rentses_url, session_id, right_status_code):
+    """Проверяет случай запроса по невалидному session_id."""
+    response = client.delete(f'{base_rentses_url}/{session_id}/cancel')
+    assert response.status_code == right_status_code
+
+
+def test_cancel_wrong_user(dbsession, rentses, base_rentses_url, another_client):  # FIXME: не работает... Вопрос: работает ли мок аутентификации из фикстуры? Как? Почему запрос проходит?(
+    """Проверяет случай запроса от пользователя, который не привязан к данной сессии."""
+    old_status = rentses.status
+    # pdb.set_trace()
+    response = another_client.delete(f'{base_rentses_url}/{rentses.id}/cancel')
+    assert response.status_code == status.HTTP_403_FORBIDDEN, 'Убедитесь, что не создатель аренды не может ее отменить!'
+    dbsession.refresh(rentses)
+    assert rentses.status == old_status, 'Убедитесь, что статус аренды не меняется при запросе не от создателя аренды!'
+
+
+@pytest.mark.parametrize(
+    'new_wrong_status',
+    [RentStatus.ACTIVE, RentStatus.CANCELED, RentStatus.OVERDUE, RentStatus.RETURNED, RentStatus.DISMISSED],
+    ids=['active', 'canceled', 'overdue', 'returned', 'dismissed']
+)
+def test_cancel_wrong_status(dbsession, client, base_rentses_url, rentses, new_wrong_status):
+    """Проверяет случай запроса на отмену незарезервированной сессии."""
+    RentalSession.update(id=rentses.id, session=dbsession, status=new_wrong_status)
+    dbsession.commit()
+    dbsession.refresh(rentses)
+    # pdb.set_trace()
+    response = client.delete(f'{base_rentses_url}/{rentses.id}/cancel')
+    assert response.status_code == status.HTTP_403_FORBIDDEN, 'Убедитесь, что нельзя отменить незарезервированную сессию!'
+    assert rentses.status == new_wrong_status, 'Убедитесь, что статус аренды не меняется при некорректном запросе!'
+
+
+def test_cancel_internal_server_error(mocker, dbsession, client, base_rentses_url, rentses):
+    """Проверяет случай возникновения неожиданной ошибки."""
+    # def mock_db_error(*args, **kwargs):
+    #     raise Exception("Database error")
+
+    error_func = mocker.patch("rental_backend.routes.rental_session.RentalSession.get", side_effect=Exception('Database error'))
+    # pdb.set_trace()
+    response = client.delete(f'{base_rentses_url}/{rentses.id}/cancel')
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR  # TODO: также добавить такую (и в остальных местах) проверку вызова мок-объекта (что падает именно из-за него).
+    assert error_func.call_count == 1, 'Убедитесь, что ошибка выпадает именно при попытке вызвать RentalSession.get!'


### PR DESCRIPTION
## Изменения
* Добавил тесты для /rental-sesssions.
* Добавил дополнительные фикстуры.
* Добавил вспомогательные функции в конец conftest.py.
* Вынес некоторые схожие проверки в "подтесты" (в test_rental_session.py).

## Детали реализации
* Тесты проводятся, по сути, без авторизации => проверки прав доступа нет.
Но я бы предложил вынести ее в отдельную задачу, так как там надо разобраться, как мокать AuthLib.
* Разкомментил LoggerMiddleware в route/base.py => даже если тесты написаны, проходить в CI они, вероятно, не будут :)
* Функции check_ под комментом Subtests в test_rental_session.py по логике универсальны, однако я не стал их выносить в conftest.py или другой отдельный файл. Просто не уверен, что надо.
* Нет проверок Event, создаваемых в хэндлерах... А они нужны?

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
