### PR TITLE
gipilipenko баг в update_rental_session

### DIFF
--- a/rental_backend/routes/rental_session.py
+++ b/rental_backend/routes/rental_session.py
@@ -7,7 +7,7 @@ from fastapi_sqlalchemy import db
 
 from rental_backend.exceptions import ForbiddenAction, InactiveSession, NoneAvailable, ObjectNotFound
 from rental_backend.models.db import Item, ItemType, RentalSession, Strike
-from rental_backend.schemas.models import RentalSessionGet, RentalSessionPatch, RentStatus, StrikeGet, StrikePost
+from rental_backend.schemas.models import RentalSessionGet, RentalSessionPatch, RentStatus, StrikePost
 from rental_backend.utils.action import ActionLogger
 
 
@@ -282,13 +282,16 @@ async def update_rental_session(
     upd_data = update_data.model_dump(exclude_unset=True)
 
     updated_session = RentalSession.update(session=db.session, id=session_id, **upd_data)
-
     ActionLogger.log_event(
         user_id=session.user_id,
         admin_id=user.get("id"),
         session_id=session.id,
         action_type="UPDATE_SESSION",
-        details={"status": session.status, "end_ts": session.end_ts, "actual_return_ts": session.actual_return_ts},
+        details={
+            "status": updated_session.status,
+            "end_ts": updated_session.end_ts.isoformat(timespec="milliseconds"),
+            "actual_return_ts": updated_session.actual_return_ts.isoformat(timespec="milliseconds"),
+        },
     )
 
     return RentalSessionGet.model_validate(updated_session)


### PR DESCRIPTION
## Изменения
Пофиксил ошибку при которой в изменении timestamp в ручке update_rental_session api выдавал 500 ошибку 

## Детали реализации
В функции ActionLogger.log_event теперь словарь details содержит ключи обновленной сессии в строковом формате, так как данный способ хранения не поддерживает datetime

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
