### PR TITLE
fixed routes to get rental_sessions

### DIFF
--- a/rental_backend/routes/rental_session.py
+++ b/rental_backend/routes/rental_session.py
@@ -4,6 +4,7 @@ import datetime
 from auth_lib.fastapi import UnionAuth
 from fastapi import APIRouter, BackgroundTasks, Depends, Query
 from fastapi_sqlalchemy import db
+from sqlalchemy.orm import joinedload
 
 from rental_backend.exceptions import ForbiddenAction, InactiveSession, NoneAvailable, ObjectNotFound
 from rental_backend.models.db import Item, ItemType, RentalSession, Strike
@@ -184,52 +185,12 @@ async def accept_end_rental_session(
     return RentalSessionGet.model_validate(ended_session)
 
 
-@rental_session.get("/user/me", response_model=list[RentalSessionGet])
-async def get_my_sessions(
-    is_reserved: bool = Query(False, description="флаг, показывать заявки"),
-    is_canceled: bool = Query(False, description="Флаг, показывать отмененные"),
-    is_dismissed: bool = Query(False, description="Флаг, показывать отклоненные"),
-    is_overdue: bool = Query(False, description="Флаг, показывать просроченные"),
-    is_returned: bool = Query(False, description="Флаг, показывать вернутые"),
-    is_active: bool = Query(False, description="Флаг, показывать активные"),
-    user=Depends(UnionAuth()),
-):
-    """
-    Получает список сессий аренды с возможностью фильтрации по статусу.
-    :param is_reserved: Флаг, показывать зарезервированные сессии.
-    :param is_canceled: Флаг, показывать отмененные сессии.
-    :param is_dismissed: Флаг, показывать отклоненные сессии.
-    :param is_overdue: Флаг, показывать просроченные сессии.
-    :param is_returned: Флаг, показывать возвращенные сессии.
-    :param is_active: Флаг, показывать активные сессии.
-    :return: Список объектов RentalSessionGet с информацией о сессиях аренды.
-    """
-    to_show = []
-    if is_reserved:
-        to_show.append(RentStatus.RESERVED)
-    if is_canceled:
-        to_show.append(RentStatus.CANCELED)
-    if is_dismissed:
-        to_show.append(RentStatus.DISMISSED)
-    if is_overdue:
-        to_show.append(RentStatus.OVERDUE)
-    if is_returned:
-        to_show.append(RentStatus.RETURNED)
-    if is_active:
-        to_show.append(RentStatus.ACTIVE)
-    query = RentalSession.query(session=db.session).filter(RentalSession.user_id == user.get("id"))
-    if to_show:
-        query = query.filter(RentalSession.status.in_(to_show))
-    user_sessions = query.all()
-    return [RentalSessionGet.model_validate(user_session) for user_session in user_sessions]
-
-
 @rental_session.get("/{session_id}", response_model=RentalSessionGet)
-async def get_rental_session(session_id: int, user=Depends(UnionAuth())):
+async def get_rental_session(session_id: int, user=Depends(UnionAuth(scopes=["rental.session.admin"]))):
 
     result = (
-        db.session.query(RentalSession, Strike.id.label("strike_id"))
-        .outerjoin(Strike, RentalSession.id == Strike.session_id)
+        db.session.query(RentalSession)
+        .options(joinedload(RentalSession.strike))
         .filter(RentalSession.id == session_id)
         .first()
     )
@@ -237,35 +198,20 @@ async def get_rental_session(session_id: int, user=Depends(UnionAuth())):
     if not result:
         raise ObjectNotFound(RentalSession, session_id)
 
-    session, strike_id = result
-
-    session_data = RentalSessionGet.model_validate(session)
-    session_data.strike_id = strike_id
-
-    return session_data
+    result.strike_id = result.strike.id if result.strike else None
+    return RentalSessionGet.model_validate(result)
 
 
-@rental_session.get("", response_model=list[RentalSessionGet])
-async def get_rental_sessions(
-    is_reserved: bool = Query(False, description="флаг, показывать заявки"),
-    is_canceled: bool = Query(False, description="Флаг, показывать отмененные"),
-    is_dismissed: bool = Query(False, description="Флаг, показывать отклоненные"),
-    is_overdue: bool = Query(False, description="Флаг, показывать просроченные"),
-    is_returned: bool = Query(False, description="Флаг, показывать вернутые"),
-    is_active: bool = Query(False, description="Флаг, показывать активные"),
-    user=Depends(UnionAuth()),
+async def get_rental_sessions_common(
+    db_session,
+    is_reserved: bool = False,
+    is_canceled: bool = False,
+    is_dismissed: bool = False,
+    is_overdue: bool = False,
+    is_returned: bool = False,
+    is_active: bool = False,
+    user_id: int = 0,
 ):
-    """
-    Получает список сессий аренды с возможностью фильтрации по статусу.
-
-    :param is_reserved: Флаг, показывать зарезервированные сессии.
-    :param is_canceled: Флаг, показывать отмененные сессии.
-    :param is_dismissed: Флаг, показывать отклоненные сессии.
-    :param is_overdue: Флаг, показывать просроченные сессии.
-    :param is_returned: Флаг, показывать возвращенные сессии.
-    :param is_active: Флаг, показывать активные сессии.
-    :return: Список объектов RentalSessionGet с информацией о сессиях аренды.
-    """
     to_show = []
     if is_reserved:
         to_show.append(RentStatus.RESERVED)
@@ -280,36 +226,19 @@ async def get_rental_sessions(
     if is_active:
         to_show.append(RentStatus.ACTIVE)
 
-    results = (
-        db.session.query(RentalSession, Strike.id.label("strike_id"))
-        .outerjoin(Strike, RentalSession.id == Strike.session_id)
-        .filter(RentalSession.user_id == user.get("id"))
-        .filter(RentalSession.status.in_(to_show) if to_show else RentalSession.user_id == user.get("id"))
-        .all()
-    )
+    if not to_show:  # if everything false by default should show all
+        to_show = list(RentStatus)
 
-    response = []
-    for session, strike_id in results:
-        session_data = RentalSessionGet.model_validate(session)
-        session_data.strike_id = strike_id
-        response.append(session_data)
+    query = db_session.query(RentalSession).options(joinedload(RentalSession.strike))
+    query = query.filter(RentalSession.status.in_(to_show))
 
-    return response
+    if user_id != 0:
+        query = query.filter(RentalSession.user_id == user_id)
 
-
-@rental_session.get("/user/{user_id}", response_model=list[RentalSessionGet])
-async def get_user_sessions(user_id: int, user=Depends(UnionAuth(scopes=["rental.session.admin"]))):
-    """
-    Retrieves a list of rental sessions for the specified user.
-
-    Scopes: `["rental.session.admin"]`
-
-    - **user_id**: The ID of the user.
-
-    Returns a list of rental sessions.
-    """
-    user_sessions = RentalSession.query(session=db.session).filter(RentalSession.user_id == user_id).all()
-    return [RentalSessionGet.model_validate(user_session) for user_session in user_sessions]
+    rent_sessions = query.all()
+    for serssion in rent_sessions:
+        serssion.strike_id = serssion.strike.id if serssion.strike else None
+    return [RentalSessionGet.model_validate(session) for session in rent_sessions]
 
 
 @rental_session.get("", response_model=list[RentalSessionGet])
@@ -320,6 +249,7 @@ async def get_rental_sessions(
     is_overdue: bool = Query(False, description="Filter by overdue sessions."),
     is_returned: bool = Query(False, description="Filter by returned sessions."),
     is_active: bool = Query(False, description="Filter by active sessions."),
+    user_id: int = Query(0, description="User_id to get sessions"),
     user=Depends(UnionAuth(scopes=["rental.session.admin"])),
 ):
     """
@@ -333,25 +263,52 @@ async def get_rental_sessions(
     - **is_overdue**: Filter by overdue sessions.
     - **is_returned**: Filter by returned sessions.
     - **is_active**: Filter by active sessions.
-
+    - **user_id**: User_id to get sessions
     Returns a list of rental sessions.
     """
-    to_show = []
-    if is_reserved:
-        to_show.append(RentStatus.RESERVED)
-    if is_canceled:
-        to_show.append(RentStatus.CANCELED)
-    if is_dismissed:
-        to_show.append(RentStatus.DISMISSED)
-    if is_overdue:
-        to_show.append(RentStatus.OVERDUE)
-    if is_returned:
-        to_show.append(RentStatus.RETURNED)
-    if is_active:
-        to_show.append(RentStatus.ACTIVE)
+    return await get_rental_sessions_common(
+        db_session=db.session,
+        is_reserved=is_reserved,
+        is_canceled=is_canceled,
+        is_dismissed=is_dismissed,
+        is_overdue=is_overdue,
+        is_returned=is_returned,
+        is_active=is_active,
+        user_id=user_id,
+    )
 
-    rent_sessions = RentalSession.query(session=db.session).filter(RentalSession.status.in_(to_show)).all()
-    return [RentalSessionGet.model_validate(rent_session) for rent_session in rent_sessions]
+
+@rental_session.get("/user/me", response_model=list[RentalSessionGet])
+async def get_my_sessions(
+    is_reserved: bool = Query(False, description="флаг, показывать заявки"),
+    is_canceled: bool = Query(False, description="Флаг, показывать отмененные"),
+    is_dismissed: bool = Query(False, description="Флаг, показывать отклоненные"),
+    is_overdue: bool = Query(False, description="Флаг, показывать просроченные"),
+    is_returned: bool = Query(False, description="Флаг, показывать вернутые"),
+    is_active: bool = Query(False, description="Флаг, показывать активные"),
+    user=Depends(UnionAuth()),
+):
+    """
+    Retrieves a list of rental sessions for the user with optional status filtering.
+
+    - **is_reserved**: Filter by reserved sessions.
+    - **is_canceled**: Filter by canceled sessions.
+    - **is_dismissed**: Filter by dismissed sessions.
+    - **is_overdue**: Filter by overdue sessions.
+    - **is_returned**: Filter by returned sessions.
+    - **is_active**: Filter by active sessions.
+    Returns a list of rental sessions.
+    """
+    return await get_rental_sessions_common(
+        db_session=db.session,
+        is_reserved=is_reserved,
+        is_canceled=is_canceled,
+        is_dismissed=is_dismissed,
+        is_overdue=is_overdue,
+        is_returned=is_returned,
+        is_active=is_active,
+        user_id=user.get('id'),
+    )
 
 
 @rental_session.delete("/{session_id}/cancel", response_model=RentalSessionGet)

--- a/tests/test_routes/test_rental_session.py
+++ b/tests/test_routes/test_rental_session.py
@@ -216,32 +216,6 @@ def test_return_with_set_end_ts(dbsession, client, base_rentses_url, active_rent
         assert response.status_code == status.HTTP_200_OK
 
 
-# Tests for GET /rental-sessions/user/{user_id}
-@pytest.mark.usefixtures('rentses')
-@pytest.mark.parametrize(
-    'user_id, right_status_code',
-    [
-        (0, status.HTTP_200_OK),  # id=0 -- это id из authlib_user.
-        ('hihi', status.HTTP_422_UNPROCESSABLE_ENTITY),
-        ('ha-ha', status.HTTP_422_UNPROCESSABLE_ENTITY),
-        ('he-he/hoho', status.HTTP_404_NOT_FOUND),
-        (-2, status.HTTP_200_OK),
-        ('', status.HTTP_422_UNPROCESSABLE_ENTITY),
-    ],
-    ids=['success', 'text', 'hyphen', 'subpath', 'unexisting_id', 'empty'],
-)
-def test_get_for_user_with_diff_id(dbsession, client, base_rentses_url, user_id, right_status_code):
-    """Проверка логики метода с разным user_id."""
-    response = client.get(f'{base_rentses_url}/user/{user_id}')
-    assert response.status_code == right_status_code
-    if right_status_code == status.HTTP_200_OK:
-        returned_queue = response.json()
-        assert isinstance(returned_queue, list), 'Убедитесь, что возвращаемый объект типа List!'
-        assert len(returned_queue) == len(
-            RentalSession.query(session=dbsession).filter(RentalSession.user_id == user_id).all()
-        )
-
-
 # Tests for GET /rental-sessions/{session_id}
 @pytest.mark.usefixtures('rentses')
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Изменения
- Изменил подход к показу strike_id, сделал его унифицированным во всех ручках через Joinedload. Выделил общую логику двух ручек в функцию
- Закрыл ручки админским скоупом
## Детали реализации
<!-- Здесь можно описать технические детали по пунктам. -->

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
