### PR TITLE
Closes: #126

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,8 +255,7 @@ def items_with_types(dbsession):
     dbsession.commit()
     yield items
     for i in item_types:
-        for item in i.items:
-            dbsession.delete(item)
+        dbsession.query(Item).filter(Item.type_id == i.id).delete(synchronize_session=False)
         dbsession.flush()
         dbsession.delete(i)
     dbsession.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,7 +255,9 @@ def items_with_types(dbsession):
     dbsession.commit()
     yield items
     for i in item_types:
-        dbsession.query(Item).filter(Item.type_id == i.id).delete(synchronize_session=False)
+        items_to_delete = dbsession.query(Item).filter(Item.type_id == i.id).all()
+        for item in items_to_delete:
+            dbsession.delete(item)
         dbsession.flush()
         dbsession.delete(i)
     dbsession.commit()


### PR DESCRIPTION
## Изменения
В items_with_types поменял teardown: вместо удаления только i.items теперь удаляются все Item с данным type_id, включая soft‑deleted


## Детали реализации
Проблема была не в тесте конкретно, а в conftest. Не было произведено полное удаление объекта БД из-за другой ссылки на него, что было исправлено.

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
