### PR TITLE
issue-114 debugged fantom deleted item problem

### DIFF
--- a/rental_backend/routes/item_type.py
+++ b/rental_backend/routes/item_type.py
@@ -196,11 +196,11 @@ async def make_item_type_available(
     """
     if count < 0:
         raise ValueError(count)
-    types = db.session.query(ItemType).filter(ItemType.id == id).one_or_none()
+    types = ItemType.query(session=db.session).filter(ItemType.id == id).one_or_none()
     if not types:
         raise ObjectNotFound(ItemType, id)
     items = (
-        db.session.query(Item)
+        Item.query(session=db.session)
         .outerjoin(
             RentalSession,
             and_(RentalSession.item_id == Item.id, RentalSession.status.in_([RentStatus.ACTIVE, RentStatus.RESERVED])),
@@ -212,9 +212,9 @@ async def make_item_type_available(
     unavailable_items = items.filter(Item.is_available == False).all()
     result = {"item_ids": [], "items_changed": 0, "total_available": len(available_items)}
     if len(available_items) >= count:
-        for i in range(len(available_items) - count):
-            updated_item = Item.update(available_items[i].id, session=db.session, is_available=False)
-            result["item_ids"].append(items[i].id)
+        for item in available_items[count:]:
+            updated_item = Item.update(item.id, session=db.session, is_available=False)
+            result["item_ids"].append(item.id)
             result["items_changed"] += 1
             result["total_available"] -= 1
             ActionLogger.log_event(
@@ -222,12 +222,12 @@ async def make_item_type_available(
                 admin_id=user.get('id'),
                 session_id=None,
                 action_type="AVAILABLE_ITEM_TYPE",
-                details={"id": items[i].id},
+                details={"id": item.id},
             )
     else:
-        for i in range(min(len(unavailable_items), count - len(available_items))):
-            updated_item = Item.update(unavailable_items[i].id, session=db.session, is_available=True)
-            result["item_ids"].append(items[i].id)
+        for item in unavailable_items[: count - len(available_items)]:
+            updated_item = Item.update(item.id, session=db.session, is_available=True)
+            result["item_ids"].append(item.id)
             result["items_changed"] += 1
             result["total_available"] += 1
 
@@ -236,7 +236,7 @@ async def make_item_type_available(
                 admin_id=user.get('id'),
                 session_id=None,
                 action_type="AVAILABLE_ITEM_TYPE",
-                details={"id": items[i].id},
+                details={"id": item.id},
             )
     return ItemTypeAvailable.model_validate(result)
 


### PR DESCRIPTION
Решена проблема с ошибкой ObjectNotFound при срабатывании эндпоинта PATCH /rental/itemtype/available/{id} после удаления любого Item.

Удаленный предмет попадал в списки available_items / unavailable_items энпоинта PATCH /rental/itemtype/available/{id}, так как неправильно был построен исходный запрос items в бд:
items = ( db.session.query(Item) .outerjoin(...).
Здесь выполнялся прямой запрос к бд через db.session.query(Item), лишенный фильтра на исключение софт делитов is_deleted. Этот фильтр определен (в base.py) и применяется в методе query родительского класса BaseDbModel, так что при дальнейшем использовании методов Item.update() (внутри которого Item.get, внутри которого Item.query) и возникала ошибка ObjectNotFound:
updated_item = Item.update(available_items[i].id, session=db.session, is_available=False)
 или
updated_item = Item.update(unavailable_items[i].id, session=db.session, is_available=True).

Банально в списке items, а как следствие в списках available_items / unavailable_items содержались Item с пометкой мягкого удаления, а в updated_item они отбрасывались, и предмет с данным id нельзя было найти.

Я переписал запрос items, добавив фильтр is_deleted, зашитый в Item.query(session=db.session)...

Также по схожей логике переписал запрос в бд для types, а то там тоже могут возникнуть проблемы с видимостью soft delete, так как при запросе нет фильтра:
types = ItemType.query(session=db.session).filter(ItemType.id == id).one_or_none().

Дополнительно:
Я заметил, что логгер эндпоинта PATCH /rental/itemtype/available/{id} очень криво выдает "item_ids". Особенно это хорошо заметно при изменении доступности сразу у многих предметов. Он может выдать последовательность id типа:
8,2,4,6,8,2,4,6, хотя должно быть 8,2,4,6,5,1,3,7 (к примеру).
Это связано с тем, что в циклах используется переменная i, но обращение идёт к items[i].id, а не к available_items[i].id или unavailable_items[i].id. Хотя списки available_items и unavailable_items являются подмножествами items, их порядок может отличаться, что и вело к неверному логированию. 
Поправил обращение к элементам в циклах, теперь логгер работает корректно.

После самостоятельных тестирований и удалений предметов никакой ошибки в работе эндпоинта и логгера замечено не было.